### PR TITLE
Check if entries actually exist before trying to get entry count

### DIFF
--- a/model/RestResource.py
+++ b/model/RestResource.py
@@ -77,6 +77,8 @@ class Resource(object):
         Get count of the entries if the resource is a collection
         :return: count of entries
         """
+        if not self.is_key_existing('entries'):
+            return 0
         return len(self.get('entries'))
 
     def get_entry(self, index):


### PR DESCRIPTION
Trying to get call `entry_count` on a resource with no entries currently results in a `TypeError` because NoneType does not have a length. This PR adds a check to have `entry_count` return 0 if there are no entries.